### PR TITLE
snapcraft plugin: prepend PRs with "snapcraft"

### DIFF
--- a/plugins/snapcraft_github/snapcraft_github.py
+++ b/plugins/snapcraft_github/snapcraft_github.py
@@ -47,7 +47,7 @@ class SnapcraftGithub(errbot.BotPlugin):
                 subscriptions[pull_request_number].add(from_nick)
         return (
             "{}: I'll send you a message if a test fails in the pull request "
-            "#{} ({}).".format(
+            "snapcraft#{} ({}).".format(
                 from_nick, pull_request.number, pull_request.title))
 
     def _get_snapcraft_repo(self):


### PR DESCRIPTION
This makes things consistent with how PRs are identified in subscriptions. It also happens to avoid the double-notification we get because mup is listening to raw PR numbers and assumes they're for snapd.