### PR TITLE
Add plugin to retrieve transfer link from build

### DIFF
--- a/plugins/snapcraft_travis/snapcraft_travis.plug
+++ b/plugins/snapcraft_travis/snapcraft_travis.plug
@@ -1,0 +1,11 @@
+[Core]
+name = SnapcraftTravis
+module = snapcraft_travis
+
+[Documentation]
+description = Handle Travis requests with the Travis API
+
+[Python]
+version = 3
+
+[Errbot]

--- a/plugins/snapcraft_travis/snapcraft_travis.py
+++ b/plugins/snapcraft_travis/snapcraft_travis.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python3
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2017 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import requests
+
+import errbot
+import git
+import github
+
+
+class SnapcraftTravis(errbot.BotPlugin):
+    """Handle Travis requests with the Travis API."""
+
+    def activate(self):
+        super().activate()
+
+    @errbot.arg_botcmd('pull_request_number', type=int)
+    def travis_snapurl(self, message, pull_request_number):
+        build_id = self._get_build_id(pull_request_number)
+        jobs = self._travis_request('build/%s' % build_id, {})['jobs']
+        # get the id for the snap job
+        job_id = jobs[3]['id']
+        log = self._travis_request('job/%s/log' % job_id, {})['content']
+        log = log.split('\n')
+        link = next((line for line in log if 'transfer.sh/' in line), 
+                    "Link not present in pull request #%i" % pull_request_number)
+        return link
+
+
+    def _travis_request(self, resource, params):        
+        url = 'https://api.travis-ci.org'
+        headers = {'Travis-API-Version': '3', 'User-Agent': 'snappy-m-o'}
+        r = requests.get(url + '/' + resource, headers=headers, params=params)
+        return r.json()
+
+    def _get_build_id(self, pull_request_number):
+        limit = 100
+        offset = 0
+
+        while True:
+            params = {'limit': limit, 'offset': offset}
+            response = self._travis_request('repo/snapcore%2Fsnapcraft/requests', params)
+            requests = response['requests']
+            if (len(requests) == 0):
+                raise errbot.ValidationException('Could not find pull request #%i'
+                                                 % pull_request_number)
+                
+            for request in requests:
+                for build in request['builds']:
+                    if build['pull_request_number'] == pull_request_number:
+                        return build['id']
+                        
+            offset += limit


### PR DESCRIPTION
Add plugin to retrieve transfer link generated from build with the Travis API, using the command 
`!travis snapurl <pull_request_number>`